### PR TITLE
explicitly create a MUI theme

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,16 +1,36 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
-import { DockerMuiThemeProvider } from "@docker/docker-mui-theme";
+import { DockerMuiV6ThemeProvider  } from "@docker/docker-mui-theme";
 import './main.css';
 
 import { App } from './App';
 
+window.__ddMuiV6Themes = {
+  dark: createTheme({
+    palette: {
+      mode: "dark",
+      background: {
+        default: "#202C33",
+      },
+    }
+  }),
+  light: createTheme({
+    palette: {
+      mode: "light",
+      background: {
+        default: "#A03232",
+      },
+    }
+  })
+};
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <DockerMuiThemeProvider>
+    <DockerMuiV6ThemeProvider >
       <CssBaseline />
       <App />
-    </DockerMuiThemeProvider>
+    </DockerMuiV6ThemeProvider >
   </React.StrictMode>
 );


### PR DESCRIPTION
Fixes #33 

After the recent dependency updates the dark/light theme info is not available by default in DockerMuiV6ThemeProvider. So, This PR creates a simple MUI theme with just the background property as that's the only thing the extension needs. The rest of the styling comes from the Open WebUI UI. 