### PR TITLE
MCPO integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,5 @@ COPY --from=builder /installer/bin/installer-windows.exe /windows/installer.exe
 COPY /searxng/limiter.toml /linux/searxng/limiter.toml
 COPY /searxng/settings.yml /linux/searxng/settings.yml
 COPY /searxng/uwsgi.ini /linux/searxng/uwsgi.ini
+COPY /mcpo/config.json /linux/mcpo/config.json
+COPY /mcpo/entrypoint.sh /linux/mcpo/entrypoint.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,14 +2,14 @@ services:
   searxng:
     image: searxng/searxng:latest
     ports:
-      - "11505:8080"
+      - "127.0.0.1:11505:8080"
     volumes:
       - ./linux/searxng:/etc/searxng
     restart: always
   mcpo:
     image: ghcr.io/open-webui/mcpo:main
     ports:
-      - "11600:8000"
+      - "127.0.0.1:11600:8000"
     volumes:
       - ./linux/mcpo:/etc/mcpo
       - /etc/rancher/k3s:/etc/rancher/k3s
@@ -19,7 +19,7 @@ services:
   open-webui:
     image: ghcr.io/open-webui/open-webui@sha256:fe7a6870ec6b2fd540c0f2007e6aa812dc4bf04a2d0a305bb344eeb10de0a7b7  # v0.6.5
     ports:
-      - "11500:8080"
+      - "127.0.0.1:11500:8080"
     volumes:
       - open-webui:/app/backend/data
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,16 @@ services:
     volumes:
       - ./linux/searxng:/etc/searxng
     restart: always
+  mcpo:
+    image: ghcr.io/open-webui/mcpo:main
+    ports:
+      - "11600:8000"
+    volumes:
+      - ./linux/mcpo:/etc/mcpo
+      - /etc/rancher/k3s:/etc/rancher/k3s
+      - /var/run/docker.sock:/var/run/docker.sock
+    entrypoint: ["/bin/sh", "/etc/mcpo/entrypoint.sh"]
+    restart: always
   open-webui:
     image: ghcr.io/open-webui/open-webui@sha256:fe7a6870ec6b2fd540c0f2007e6aa812dc4bf04a2d0a305bb344eeb10de0a7b7  # v0.6.5
     ports:
@@ -13,6 +23,7 @@ services:
     volumes:
       - open-webui:/app/backend/data
     environment:
+      - DEFAULT_USER_ROLE=user
       - WEBUI_AUTH=False
       - WEBUI_SESSION_COOKIE_SAME_SITE=None
       - WEBUI_SESSION_COOKIE_SECURE=True

--- a/mcpo/config.json
+++ b/mcpo/config.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "docker-mcp": {
+      "command": "uvx",
+      "args": [
+        "docker-mcp"
+      ]
+    },
+    "kubernetes": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "kubernetes-mcp-server@latest"
+      ]
+    }
+  }
+}

--- a/mcpo/entrypoint.sh
+++ b/mcpo/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+echo "Running uname -m..."
+ARCH="$(uname -m)"
+echo "Raw architecture output: $ARCH"
+
+case "$ARCH" in
+  x86_64) ARCH_TAG="amd64" ;;
+  aarch64|arm64) ARCH_TAG="arm64" ;;
+  *)
+    echo "Unsupported architecture: '$ARCH'"
+    exit 1
+    ;;
+esac
+
+echo "Detected architecture tag: $ARCH_TAG"
+
+# Install Docker CLI
+echo "Installing Docker CLI..."
+curl -sSL "https://github.com/rancher-sandbox/rancher-desktop-docker-cli/releases/download/v28.1.1/docker-linux-${ARCH_TAG}" -o /usr/local/bin/docker
+chmod +x /usr/local/bin/docker
+echo "Docker CLI installed."
+
+# Install Docker Compose
+echo "Installing Docker Compose..."
+curl -sSL "https://github.com/docker/compose/releases/download/v2.18.0/docker-compose-linux-${ARCH_TAG}" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+echo "Docker Compose installed."
+
+# Install kubectl
+echo "Installing kubectl..."
+curl -sSL "https://dl.k8s.io/release/v1.33.0/bin/linux/${ARCH_TAG}/kubectl" -o /usr/local/bin/kubectl
+chmod +x /usr/local/bin/kubectl
+echo "kubectl installed."
+
+mkdir -p ~/.kube
+cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sed -i 's/127.0.0.1/host.docker.internal/g' ~/.kube/config
+
+# Install Helm
+echo "Installing Helm..."
+curl -sSL "https://get.helm.sh/helm-v3.17.3-linux-${ARCH_TAG}.tar.gz" -o /tmp/helm.tar.gz
+tar -xzvf /tmp/helm.tar.gz -C /tmp
+mv /tmp/linux-${ARCH_TAG}/helm /usr/local/bin/helm
+chmod +x /usr/local/bin/helm
+rm -rf /tmp/helm.tar.gz /tmp/linux-${ARCH_TAG}
+echo "Helm installed."
+
+# Start mcpo
+echo "Starting mcpo..."
+exec mcpo --api-key "" --config /etc/mcpo/config.json

--- a/mcpo/entrypoint.sh
+++ b/mcpo/entrypoint.sh
@@ -15,36 +15,40 @@ esac
 
 echo "Detected architecture tag: $ARCH_TAG"
 
-# Install Docker CLI
-echo "Installing Docker CLI..."
-curl -sSL "https://github.com/rancher-sandbox/rancher-desktop-docker-cli/releases/download/v28.1.1/docker-linux-${ARCH_TAG}" -o /usr/local/bin/docker
-chmod +x /usr/local/bin/docker
-echo "Docker CLI installed."
+if [ -e "/var/run/docker.sock" ]; then
+  # Install Docker CLI
+  echo "Installing Docker CLI..."
+  curl -sSL "https://github.com/rancher-sandbox/rancher-desktop-docker-cli/releases/download/v28.1.1/docker-linux-${ARCH_TAG}" -o /usr/local/bin/docker
+  chmod +x /usr/local/bin/docker
+  echo "Docker CLI installed."
 
-# Install Docker Compose
-echo "Installing Docker Compose..."
-curl -sSL "https://github.com/docker/compose/releases/download/v2.18.0/docker-compose-linux-${ARCH_TAG}" -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-echo "Docker Compose installed."
+  # Install Docker Compose
+  echo "Installing Docker Compose..."
+  curl -sSL "https://github.com/docker/compose/releases/download/v2.18.0/docker-compose-linux-${ARCH_TAG}" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+  echo "Docker Compose installed."
+fi
 
-# Install kubectl
-echo "Installing kubectl..."
-curl -sSL "https://dl.k8s.io/release/v1.33.0/bin/linux/${ARCH_TAG}/kubectl" -o /usr/local/bin/kubectl
-chmod +x /usr/local/bin/kubectl
-echo "kubectl installed."
+if [ -e "/etc/rancher/k3s/k3s.yaml" ]; then
+  # Install kubectl
+  echo "Installing kubectl..."
+  curl -sSL "https://dl.k8s.io/release/v1.33.0/bin/linux/${ARCH_TAG}/kubectl" -o /usr/local/bin/kubectl
+  chmod +x /usr/local/bin/kubectl
+  echo "kubectl installed."
 
-mkdir -p ~/.kube
-cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-sed -i 's/127.0.0.1/host.docker.internal/g' ~/.kube/config
+  mkdir -p ~/.kube
+  cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+  sed -i 's/127.0.0.1/host.docker.internal/g' ~/.kube/config
 
-# Install Helm
-echo "Installing Helm..."
-curl -sSL "https://get.helm.sh/helm-v3.17.3-linux-${ARCH_TAG}.tar.gz" -o /tmp/helm.tar.gz
-tar -xzvf /tmp/helm.tar.gz -C /tmp
-mv /tmp/linux-${ARCH_TAG}/helm /usr/local/bin/helm
-chmod +x /usr/local/bin/helm
-rm -rf /tmp/helm.tar.gz /tmp/linux-${ARCH_TAG}
-echo "Helm installed."
+  # Install Helm
+  echo "Installing Helm..."
+  curl -sSL "https://get.helm.sh/helm-v3.17.3-linux-${ARCH_TAG}.tar.gz" -o /tmp/helm.tar.gz
+  tar -xzvf /tmp/helm.tar.gz -C /tmp
+  mv /tmp/linux-${ARCH_TAG}/helm /usr/local/bin/helm
+  chmod +x /usr/local/bin/helm
+  rm -rf /tmp/helm.tar.gz /tmp/linux-${ARCH_TAG}
+  echo "Helm installed."
+fi
 
 # Start mcpo
 echo "Starting mcpo..."

--- a/mcpo/entrypoint.sh
+++ b/mcpo/entrypoint.sh
@@ -17,37 +17,53 @@ echo "Detected architecture tag: $ARCH_TAG"
 
 if [ -e "/var/run/docker.sock" ]; then
   # Install Docker CLI
-  echo "Installing Docker CLI..."
-  curl -sSL "https://github.com/rancher-sandbox/rancher-desktop-docker-cli/releases/download/v28.1.1/docker-linux-${ARCH_TAG}" -o /usr/local/bin/docker
-  chmod +x /usr/local/bin/docker
-  echo "Docker CLI installed."
+  if [ -e "/usr/local/bin/docker" ]; then
+    echo "Docker CLI is already installed."
+  else
+    echo "Installing Docker CLI..."
+    curl -sSL "https://github.com/rancher-sandbox/rancher-desktop-docker-cli/releases/download/v28.1.1/docker-linux-${ARCH_TAG}" -o /usr/local/bin/docker
+    chmod +x /usr/local/bin/docker
+    echo "Docker CLI installed."
+  fi
 
   # Install Docker Compose
-  echo "Installing Docker Compose..."
-  curl -sSL "https://github.com/docker/compose/releases/download/v2.18.0/docker-compose-linux-${ARCH_TAG}" -o /usr/local/bin/docker-compose
-  chmod +x /usr/local/bin/docker-compose
-  echo "Docker Compose installed."
+  if [ -e "/usr/local/bin/docker-compose" ]; then
+    echo "Docker Compose is already installed."
+  else
+    echo "Installing Docker Compose..."
+    curl -sSL "https://github.com/docker/compose/releases/download/v2.18.0/docker-compose-linux-${ARCH_TAG}" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+    echo "Docker Compose installed."
+  fi
 fi
 
 if [ -e "/etc/rancher/k3s/k3s.yaml" ]; then
   # Install kubectl
-  echo "Installing kubectl..."
-  curl -sSL "https://dl.k8s.io/release/v1.33.0/bin/linux/${ARCH_TAG}/kubectl" -o /usr/local/bin/kubectl
-  chmod +x /usr/local/bin/kubectl
-  echo "kubectl installed."
+  if [ -e "/usr/local/bin/kubectl" ]; then
+    echo "kubectl is already installed."
+  else
+    echo "Installing kubectl..."
+    curl -sSL "https://dl.k8s.io/release/v1.33.0/bin/linux/${ARCH_TAG}/kubectl" -o /usr/local/bin/kubectl
+    chmod +x /usr/local/bin/kubectl
+    echo "kubectl installed."
+  fi
 
   mkdir -p ~/.kube
   cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
   sed -i 's/127.0.0.1/host.docker.internal/g' ~/.kube/config
 
   # Install Helm
-  echo "Installing Helm..."
-  curl -sSL "https://get.helm.sh/helm-v3.17.3-linux-${ARCH_TAG}.tar.gz" -o /tmp/helm.tar.gz
-  tar -xzvf /tmp/helm.tar.gz -C /tmp
-  mv /tmp/linux-${ARCH_TAG}/helm /usr/local/bin/helm
-  chmod +x /usr/local/bin/helm
-  rm -rf /tmp/helm.tar.gz /tmp/linux-${ARCH_TAG}
-  echo "Helm installed."
+  if [ -e "/usr/local/bin/helm" ]; then
+    echo "Helm is already installed."
+  else
+    echo "Installing Helm..."
+    curl -sSL "https://get.helm.sh/helm-v3.17.3-linux-${ARCH_TAG}.tar.gz" -o /tmp/helm.tar.gz
+    tar -xzvf /tmp/helm.tar.gz -C /tmp
+    mv /tmp/linux-${ARCH_TAG}/helm /usr/local/bin/helm
+    chmod +x /usr/local/bin/helm
+    rm -rf /tmp/helm.tar.gz /tmp/linux-${ARCH_TAG}
+    echo "Helm installed."
+  fi
 fi
 
 # Start mcpo

--- a/metadata.json
+++ b/metadata.json
@@ -30,6 +30,12 @@
           },
           {
             "path": "/linux/searxng/uwsgi.ini"
+          },
+          {
+            "path": "/linux/mcpo/config.json"
+          },
+          {
+            "path": "/linux/mcpo/entrypoint.sh"
           }
         ],
         "windows": [


### PR DESCRIPTION
This PR runs the mcpo container and does the required wiring to add 2 MCP servers, [mcp-server-docker](https://github.com/ckreiling/mcp-server-docker), [mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes) that allow you to chat with the container engine and Kubernetes in natural language.

Note: To avoid building and maintaining our own version of the mcpo container image to install the required utilities such as docker, helm etc, those tools are installed at the container start.
