### PR TITLE
download latest ollama and OI releases

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   searxng:
     image: searxng/searxng:latest
+    pull_policy: always
     ports:
       - "127.0.0.1:11505:8080"
     volumes:
@@ -8,6 +9,7 @@ services:
     restart: always
   mcpo:
     image: ghcr.io/open-webui/mcpo:main
+    pull_policy: always
     ports:
       - "127.0.0.1:11600:8000"
     volumes:
@@ -18,6 +20,7 @@ services:
     restart: always
   open-webui:
     image: ghcr.io/open-webui/open-webui:latest
+    pull_policy: always
     ports:
       - "127.0.0.1:11500:8080"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     entrypoint: ["/bin/sh", "/etc/mcpo/entrypoint.sh"]
     restart: always
   open-webui:
-    image: ghcr.io/open-webui/open-webui@sha256:fda936056184035a71a9ad5ff3721530ff061f16bc3907efb33a3201ba87ccfe  # v0.6.15
+    image: ghcr.io/open-webui/open-webui:latest
     ports:
       - "127.0.0.1:11500:8080"
     volumes:

--- a/installer/main.go
+++ b/installer/main.go
@@ -33,7 +33,7 @@ const (
 var (
 	mode           = ModeInstall
 	allModes       = []Mode{ModeInstall, ModeUninstall, ModeCheck, ModeStart, ModeShutdown}
-	releaseVersion = flag.String("release", "v0.9.2", "release to download when installing")
+	releaseVersion = flag.String("release", "latest", "release to download when installing")
 	pullModel      = flag.String("model", "tinyllama", "model to pull on install; set to empty string to skip")
 )
 


### PR DESCRIPTION
Fixes #107 

Always install the latest releases of Ollama and OI. Even though it's not inline with Rancher Desktop to include latest and untested tools, this is an exception as the upstream projects bundled in this extension rapidly release new versions with features that users want to try out.

A better approach for later might be if this extension is upgraded in some automated way via something like updatecli and then users who want to install the latest version can install via `rdctl`.